### PR TITLE
fix: set maturin args to build the web-viewer.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,4 +9,5 @@ if errorlevel 1 exit 1
 REM Run the maturin build via pip
 set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
+set MATURIN_PEP517_ARGS="--features pypi"
 %PYTHON% -m pip install rerun_py/ -vv

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,5 +9,5 @@ if errorlevel 1 exit 1
 REM Run the maturin build via pip
 set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
-set MATURIN_PEP517_ARGS="--features pypi"
+set MATURIN_PEP517_ARGS=--features pypi
 %PYTHON% -m pip install rerun_py/ -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,4 +9,4 @@ cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 # Run the maturin build via pip which works for direct and
 # cross-compiled builds.
-"${PYTHON}" -m pip install rerun_py/ -vv
+MATURIN_PEP517_ARGS="--features pypi" "${PYTHON}" -m pip install rerun_py/ -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,15 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - crossenv                               # [build_platform != target_platform]
+    - maturin >=0.14,<0.15                   # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cargo-bundle-licenses
@@ -27,7 +29,6 @@ requirements:
     - semver >=2.13,<2.14
     - wheel >=0.38,<0.39
     - pytest
-    - maturin >=0.14,<0.15
     - binaryen
   host:
     - pip


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This should fix the fact that the `rerun --web-viewer` doesn't work. This broke because we changed form running maturin in the build script to letting pip run it using the pyproject.toml. 