### PR TITLE
fix: python issues

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,9 @@
 REM https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
 set CARGO_NET_GIT_FETCH_WITH_CLI=true
 
+REM Point PyO3 to the right interpreter
+set "PYO3_PYTHON=%PYTHON%"
+
 REM Bundle all downstream library licenses
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,15 @@ source:
   url: https://github.com/rerun-io/rerun/archive/refs/tags/{{ version }}.tar.gz
   sha256: 39974e2eeda49594e2c61f0aa86eb5420097297cc8925f43e8da5fb23c259334
 
-
 build:
   number: 1
   skip: true  # [py<38]
 
 requirements:
   build:
-    - python                                 
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - crossenv                               # [build_platform != target_platform]
+    - python                                 # [build_platform != target_platform]
     - maturin >=0.14,<0.15                   # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
@@ -29,14 +28,12 @@ requirements:
     {% if target_platform == "osx-arm64" %}
     - rust-std-aarch64-apple-darwin
     {% endif %}
-    - semver >=2.13,<2.14
-    - wheel >=0.38,<0.39
-    - pytest
+    # binaryen gives us wasm-opt, for optimizing the an .wasm file for speed and size
     - binaryen
   host:
+    - python  
     - pip
-    - python
-    - maturin >=0.14,<0.15 
+    - maturin >=0.14,<0.15    
   run:
     - python
     - attrs >=23.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,12 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
+    - python                                 
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - crossenv                               # [build_platform != target_platform]
     - maturin >=0.14,<0.15                   # [build_platform != target_platform]
@@ -36,7 +36,7 @@ requirements:
   host:
     - pip
     - python
-    - maturin
+    - maturin >=0.14,<0.15 
   run:
     - python
     - attrs >=23.1.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I think the issue was as follows:

* None of the builds are cross-compiling so all lines with `# [build_platform != target_platform]` are disabled.
* Some dependencies in the build (e.g. `semver`) depend on python. 
* Because Python is an implicit dependency (because of the above) it is not pinned! (So the latest version is selected, not the pinned version).
* So by removing the conditional flags of python in the build section we ensure that it is also pinned to the correct version.

* Lastly, the maturin version had different requirements in the (disabled) build section than the host section. I changed this to use the same requirements as in the pyproject.toml.

I am unfamiliar with the build process of rerun-sdk but I think the python dependencies should also be moved to the host section.


--- 

I ended up changing the thing completely because I dont know why there is a dependency on wheel and semver in the first place. I removed those to see what happens. :)