### PR TITLE
fix: add python entry point

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,10 @@ source:
   sha256: 39974e2eeda49594e2c61f0aa86eb5420097297cc8925f43e8da5fb23c259334
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<38]
+  entry_points:
+    - rerun = rerun.__main__:main
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
When running `rerun` on Windows I run into this error:

```
Fatal error in launcher: Unable to create process using '"D:\bld\rerun-sdk_1697490036427\_h_env\python.exe"  "E:\Developer\prefix\rerun\.pixi\env\Scripts\rerun.EXE" ': The system cannot find the file specified.
```

It appears the prefix `D:\bld\rerun-sdk_1697490036427\_h_env` was not properly replaced by the build. I think this behavior is overwritten when manually specifying an entry point which is what this PR adds.