### PR TITLE
Remove RERUN_IS_PUBLISHING and bump to 0.10.0

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -80,6 +80,7 @@ docker pull "${DOCKER_IMAGE}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+           -e CONDA_BUILD \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,9 @@ set CARGO_NET_GIT_FETCH_WITH_CLI=true
 REM Point PyO3 to the right interpreter
 set "PYO3_PYTHON=%PYTHON%"
 
+REM The CI environment variable means something specific to Rerun. Unset it.
+set CI=
+
 REM Bundle all downstream library licenses
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,7 +12,6 @@ if errorlevel 1 exit 1
 REM Run the maturin build via pip
 set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
-set RERUN_IS_PUBLISHING=yes
 
 cargo run --locked -p re_build_web_viewer -- --release
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,9 @@ export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml 
 
+# The CI environment variable means something specific to Rerun. Unset it.
+unset CI
+
 if [[ $CONDA_BUILD_CROSS_COMPILATION == "1"  && $target_platform == "osx-arm64" ]]; then
     MATURIN_CROSS_TARGET="--target aarch64-apple-darwin"
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,8 +11,6 @@ if [[ $CONDA_BUILD_CROSS_COMPILATION == "1"  && $target_platform == "osx-arm64" 
     MATURIN_CROSS_TARGET="--target aarch64-apple-darwin"
 fi
 
-export RERUN_IS_PUBLISHING=yes
-
 cargo run --locked -p re_build_web_viewer -- --release
 
 # Run the maturin build via pip which works for direct and

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 39974e2eeda49594e2c61f0aa86eb5420097297cc8925f43e8da5fb23c259334
 
 build:
-  number: 2
+  number: 3
   skip: true  # [py<38]
   entry_points:
     - rerun = rerun.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a949aa7b941053d4ce7d241b5471d5ef3a10c59d759b40f3d07a6a13872b381f
 
 build:
-  number: 3
+  number: 0
   skip: true  # [py<38]
   entry_points:
     - rerun = rerun.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rerun-sdk" %}
-{% set version = "0.9.1" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rerun-io/rerun/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 39974e2eeda49594e2c61f0aa86eb5420097297cc8925f43e8da5fb23c259334
+  sha256: a949aa7b941053d4ce7d241b5471d5ef3a10c59d759b40f3d07a6a13872b381f
 
 build:
   number: 3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Combined with the changes from:
 - https://github.com/rerun-io/rerun/pull/4015

This fixes:
 - https://github.com/rerun-io/rerun/issues/3908

`RERUN_IS_PUBLISHING` is used for the crate publishing and Rerun now handles this properly by checking for the `CONDA_BUILD` environment variable.

Note: this fix won't actually work until we release `rerun-0.10` with the fix from https://github.com/rerun-io/rerun/pull/4015
