### PR TITLE
Unset IS_IN_RERUN_WORKSPACE so example manifest gets set up properly

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ set "PYO3_PYTHON=%PYTHON%"
 
 REM The CI environment variable means something specific to Rerun. Unset it.
 set CI=
+set IS_IN_RERUN_WORKSPACE="no"
 
 REM Bundle all downstream library licenses
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,7 @@ set -ex
 
 # https://github.com/rust-lang/cargo/issues/10583#issuecomment-1129997984
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
+export IS_IN_RERUN_WORKSPACE=no
 
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9f40039123f8e1cdc19f8667f8c986b938bff36b0d7cc1c9d9a8723768a072c8
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   entry_points:
     - rerun = rerun.__main__:main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
