### PR TITLE
Only set MACOSX_*** overrides in conda_build_config.yaml for x86_64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,5 @@
 # Needed for Metal, the hardware acceleration api for osx
-MACOSX_SDK_VERSION:        # [osx]
-  - "11.0"                 # [osx]
-MACOSX_DEPLOYMENT_TARGET:  # [osx]
-  - '10.12'                # [osx]
-
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "11.0"                 # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - '10.12'                # [osx and x86_64]


### PR DESCRIPTION
@xhochy originally raised the point in https://github.com/conda-forge/staged-recipes/pull/25648#discussion_r1524382297. 

Setting this only for x86_64 is necessary as on osx-arm64 the default value of `MACOSX_DEPLOYMENT_TARGET` is already 11, see https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/070f9140d5ab27ef0d109c6b65c80cf0756bbe26/recipe/conda_build_config.yaml#L111, and there is no reason to override it with a lower value.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

