### PR TITLE
Add nasm dependency and feature

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,7 +18,7 @@ set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
 
 REM Build the rerun-cli and insert it into the python package
-cargo build --package rerun-cli --no-default-features --features native_viewer --release
+cargo build --package rerun-cli --no-default-features --features native_viewer,nasm --release
 dir target
 dir target\release
 copy target\release\rerun.exe rerun_py\rerun_sdk\rerun_cli\rerun.exe

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,7 +36,7 @@ else
 fi
 
 # Build the rerun-cli and insert it into the python package
-cargo build --package rerun-cli $CROSS_TARGET --no-default-features --features native_viewer --release
+cargo build --package rerun-cli $CROSS_TARGET --no-default-features --features native_viewer,nasm --release
 cp target/$RUST_TARGET/release/rerun rerun_py/rerun_sdk/rerun_cli/rerun 
 
 # Build the rerun-web-viewer assets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - disable_wayland.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   entry_points:
     - rerun = rerun.__main__:main
@@ -38,6 +38,7 @@ requirements:
     # binaryen gives us wasm-opt, for optimizing the an .wasm file for speed and size
     - binaryen
     - nodejs >=20.12
+    - nasm
   host:
     - anywidget
     - hatch


### PR DESCRIPTION
To solve "Failed to create VideoDecoder" error, reported by @pablovela5620 in https://discord.com/channels/1062300748202921994/1296973504532447312/1296973504532447312 .

I am not familiar with the rationale behind the `--no-default-features`, so I kind adapted from https://github.com/rerun-io/rerun/pull/7742 that seems related, but probably before merging it could make sense to get @jleibs feedback and understand if we need to enable the same feature also for Python and C++ bindings, beside enabling it in `rerun-cli`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
