### PR TITLE
Add missing ipykernel run dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fee9ec1a46e927e421eda5caec122aac2278d3d5ff24c2dbd9289f88bf318d59
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   # nodejs doesn't support ppc64le
   skip: true  # [ppc64le]
@@ -52,6 +52,7 @@ requirements:
     - attrs >=23.1.0
     - anywidget
     - jupyter-ui-poll
+    - ipykernel <7.0.0
     - numpy >=1.23
     - pillow >=8.0.0
     - psutil >=7.0


### PR DESCRIPTION
This package bundles rerun-notebook, whose PyPI metadata requires ipykernel<7.0.0 unconditionally. This makes pip check fails for any environment that installs a package depending on rerun-sdk.

Also present in [newton-feedstock](https://github.com/conda-forge/newton-feedstock/blob/07082443cf75e0c05e525f10f3aae48dfa65ce6a/recipe/recipe.yaml#L158-L159) (fyi @conda-forge/newton) and lerobot-feedstock (see https://github.com/conda-forge/lerobot-feedstock/pull/15)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
