### PR TITLE
Scope LLVM toolchain to WASM builds

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,8 +8,16 @@ set "PYO3_PYTHON=%PYTHON%"
 REM The CI environment variable means something specific to Rerun. Unset it.
 set CI=
 set IS_IN_RERUN_WORKSPACE=no
-::set "AR=%CONDA_PREFIX%\Library\bin\llvm-ar.exe"
-set AR=llvm-ar
+
+REM conda's compiler activation configures the native compiler and archiver.
+REM Rust's cc crate gives target-qualified tool variables precedence, so keep the
+REM LLVM toolchain scoped to the web viewer's WASM target. ring requires Clang for
+REM wasm32, and llvm-ar avoids host-specific archives.
+set "CC_wasm32_unknown_unknown=clang"
+set "CXX_wasm32_unknown_unknown=clang++"
+set "AR_wasm32_unknown_unknown=llvm-ar"
+set "CFLAGS_wasm32_unknown_unknown=-fno-stack-protector"
+set "CXXFLAGS_wasm32_unknown_unknown=-fno-stack-protector"
 
 REM Configure Rust to use conda-installed wasm32 target
 REM Try multiple possible locations where conda might install the target
@@ -27,16 +35,6 @@ if exist "%CONDA_PREFIX%\Library\lib\rustlib\wasm32-unknown-unknown" (
     dir "%CONDA_PREFIX%" /s /b | findstr "wasm32-unknown-unknown" 2>nul
     echo Warning: wasm32-unknown-unknown target not found in expected conda locations
 )
-set CLANG_MAJOR_VERSION=16
-set CLANG_RESOURCE_DIR=%CONDA_PREFIX%\Library\lib\clang\%CLANG_MAJOR_VERSION%
-set LIBCLANG_INCLUDE=%CONDA_PREFIX%\Library\lib\clang\%CLANG_MAJOR_VERSION%\include
-REM Add -fno-stack-protector to disable stack protection for WASM
-set CFLAGS_wasm32_unknown_unknown=-isystem %LIBCLANG_INCLUDE% -resource-dir %CLANG_RESOURCE_DIR% -fno-stack-protector
-set CXXFLAGS_wasm32_unknown_unknown=-fno-stack-protector
-set CC_wasm32_unknown_unknown=clang
-
-
-set PATH=%CONDA_PREFIX%\Library\bin;%PATH%
 
 REM Bundle all downstream library licenses
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
@@ -52,12 +50,22 @@ ensure-pyo3-build-cfg
 
 REM Build the rerun-web-viewer assets
 set RUST_BACKTRACE=1
-rustc --print target-list
-where rustc
-where cargo
-where clang
-clang -print-targets
+REM cc-rs appends target-specific flags to generic flags, so clear conda's
+REM native flags only for this WASM build. setlocal restores them before the
+REM native CLI and Python extension are built.
+setlocal
+set "CFLAGS="
+set "CXXFLAGS="
+set "CPPFLAGS="
+set "TARGET_CFLAGS="
+set "TARGET_CXXFLAGS="
+set "TARGET_CPPFLAGS="
 cargo run --locked -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --release -g
+if errorlevel 1 (
+    endlocal
+    exit /b 1
+)
+endlocal
 
 REM Build the rerun-cli and insert it into the python package
 cargo build --package rerun-cli --no-default-features --features release_full --release

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -87,7 +87,22 @@ set MATURIN_PEP517_ARGS=--features pypi
 
 npm i yarn
 npx yarn install --cwd rerun_js
+
+REM The JavaScript package build invokes Cargo for WASM a second time, so it
+REM must not inherit conda's native C/C++ flags either.
+setlocal
+set "CFLAGS="
+set "CXXFLAGS="
+set "CPPFLAGS="
+set "TARGET_CFLAGS="
+set "TARGET_CXXFLAGS="
+set "TARGET_CPPFLAGS="
 npx yarn --cwd rerun_js/web-viewer run build
+if errorlevel 1 (
+    endlocal
+    exit /b 1
+)
+endlocal
 
 REM Remove node_modules to free up space
 rd /s /q rerun_js\node_modules

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,21 +11,21 @@ cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 # The CI environment variable means something specific to Rerun. Unset it.
 unset CI
 
-# TODO(nick): Parse Major version from clang instead of hardocoding it.
-CLANG_MAJOR_VERSION="16"
-CLANG_RESOURCE_DIR="${CONDA_PREFIX}/lib/clang/$CLANG_MAJOR_VERSION"
-# Use libclang's include directory which has the standard headers
-LIBCLANG_INCLUDE="${CONDA_PREFIX}/lib/clang/$CLANG_MAJOR_VERSION/include"
+# conda's compiler activation configures the native compiler and archiver.
+# Rust's cc crate gives target-qualified tool variables precedence, so keep the
+# LLVM toolchain scoped to the web viewer's WASM target. ring requires Clang for
+# wasm32, and llvm-ar avoids host-specific archives.
+export CC_wasm32_unknown_unknown="clang"
+export CXX_wasm32_unknown_unknown="clang++"
+export AR_wasm32_unknown_unknown="llvm-ar"
+export CFLAGS_wasm32_unknown_unknown="-fno-stack-protector"
+export CXXFLAGS_wasm32_unknown_unknown="-fno-stack-protector"
 
 case "$target_platform" in
     "linux-64")
-        export CFLAGS_wasm32_unknown_unknown="-isystem $LIBCLANG_INCLUDE -resource-dir $CLANG_RESOURCE_DIR"
-        export CC_wasm32_unknown_unknown="${CONDA_PREFIX}/bin/clang"
         export RUST_TARGET="x86_64-unknown-linux-gnu"
         ;;
     "linux-aarch64")
-        export CFLAGS_wasm32_unknown_unknown="-isystem $LIBCLANG_INCLUDE -resource-dir $CLANG_RESOURCE_DIR"
-        export CC_wasm32_unknown_unknown="${CONDA_PREFIX}/bin/clang"
         export RUST_TARGET="aarch64-unknown-linux-gnu"
         # libudev-sys' build script calls the Rust pkg-config crate, which
         # refuses to run when host != target unless this is set. Needed so
@@ -34,36 +34,15 @@ case "$target_platform" in
         export PKG_CONFIG_ALLOW_CROSS=1
         ;;
     "osx-64")
-        CLANG_MAJOR_VERSION="19"
-        CLANG_RESOURCE_DIR="${CONDA_PREFIX}/lib/clang/$CLANG_MAJOR_VERSION"
-        # Use libclang's include directory which has the standard headers
-        LIBCLANG_INCLUDE="${CONDA_PREFIX}/lib/clang/$CLANG_MAJOR_VERSION/include"
-
-        export AR="${CONDA_PREFIX}/bin/llvm-ar"
-        export CFLAGS_wasm32_unknown_unknown="-isystem $LIBCLANG_INCLUDE -resource-dir $CLANG_RESOURCE_DIR"
-        # Hmm it should use the target specific flags but it doesn't
-        export TARGET_CFLAGS="-isystem $LIBCLANG_INCLUDE -resource-dir $CLANG_RESOURCE_DIR"
-        # This might impact performance, and break something else but is needed for ring wasm target
-        export CFLAGS="-isystem $LIBCLANG_INCLUDE -resource-dir $CLANG_RESOURCE_DIR"
-        export CC_wasm32_unknown_unknown="${CONDA_PREFIX}/bin/clang"
-        # Since we clobber CFLAGS need to clobber CC as well
-        export CC="${CONDA_PREFIX}/bin/clang"
-        export CC_x86_64_apple_darwin="${CONDA_PREFIX}/bin/clang"
         export RUST_TARGET="x86_64-apple-darwin"
         ;;
     "osx-arm64")
-        export AR="${CONDA_PREFIX}/bin/llvm-ar"
         export RUST_TARGET="aarch64-apple-darwin"
         ;;
     "win-64")
-        export AR="${CONDA_PREFIX}/bin/llvm-ar"
         export RUST_TARGET="x86_64-pc-windows-msvc"
         ;;
 esac
-
-# Need to disable stack-protector for wasm-bindgen
-export CFLAGS_wasm32_unknown_unknown="${CFLAGS_wasm32_unknown_unknown} -fno-stack-protector"
-export CXXFLAGS_wasm32_unknown_unknown="${CXXFLAGS_wasm32_unknown_unknown} -fno-stack-protector"
 
 if [[ $CONDA_BUILD_CROSS_COMPILATION == "1"  && $target_platform == "osx-arm64" ]]; then
     export CROSS_TARGET="--target aarch64-apple-darwin"
@@ -75,8 +54,14 @@ export PIXI_PROJECT_ROOT=$(pwd)
 "${PYTHON}" -m pip install rerun_pixi_env/
 ensure-pyo3-build-cfg
 
-# Build the rerun-web-viewer assets
-cargo run --locked -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --release -g
+# Build the rerun-web-viewer assets. cc-rs appends target-specific flags to
+# generic flags, so clear conda's native flags only for this WASM build. The
+# subshell restores them before the native CLI and Python extension are built.
+(
+    unset CFLAGS CXXFLAGS CPPFLAGS
+    unset TARGET_CFLAGS TARGET_CXXFLAGS TARGET_CPPFLAGS
+    cargo run --locked -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --release -g
+)
 
 # Build the rerun-cli and insert it into the python package
 cargo build --package rerun-cli $CROSS_TARGET --no-default-features --features release_full --release

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -54,14 +54,20 @@ export PIXI_PROJECT_ROOT=$(pwd)
 "${PYTHON}" -m pip install rerun_pixi_env/
 ensure-pyo3-build-cfg
 
-# Build the rerun-web-viewer assets. cc-rs appends target-specific flags to
-# generic flags, so clear conda's native flags only for this WASM build. The
-# subshell restores them before the native CLI and Python extension are built.
-(
-    unset CFLAGS CXXFLAGS CPPFLAGS
-    unset TARGET_CFLAGS TARGET_CXXFLAGS TARGET_CPPFLAGS
-    cargo run --locked -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --release -g
-)
+# cc-rs appends target-specific flags to generic flags. Clear conda's native
+# flags for every WASM build so options such as -march and -isystem are not
+# passed to clang --target=wasm32-unknown-unknown. Each subshell restores the
+# flags before the native CLI and Python extension are built.
+run_wasm_build() {
+    (
+        unset CFLAGS CXXFLAGS CPPFLAGS
+        unset TARGET_CFLAGS TARGET_CXXFLAGS TARGET_CPPFLAGS
+        "$@"
+    )
+}
+
+# Build the rerun-web-viewer assets.
+run_wasm_build cargo run --locked -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --release -g
 
 # Build the rerun-cli and insert it into the python package
 cargo build --package rerun-cli $CROSS_TARGET --no-default-features --features release_full --release
@@ -73,5 +79,6 @@ MATURIN_PEP517_ARGS="$CROSS_TARGET --features pypi" "${PYTHON}" -m pip install r
 
 npm i yarn
 npx yarn install --cwd rerun_js
-npx yarn --cwd rerun_js/web-viewer run build
+# The JavaScript package build invokes Cargo for WASM a second time.
+run_wasm_build npx yarn --cwd rerun_js/web-viewer run build
 "${PYTHON}" -m pip install rerun_notebook/ -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,6 @@ build:
   skip: true  # [ppc64le]
   entry_points:
     - rerun = rerun.__main__:main
-  script_env:
-    - AR
   # gilrs (gamepad support, new in rerun 0.34.0) links the always-present
   # WinRT API-set umbrella DLL, which conda-build's overlinking check flags
   missing_dso_whitelist:
@@ -41,7 +39,10 @@ requirements:
     - binaryen
     - nodejs >=20.12
     - nasm
-    - clang ==16.0.6  # [not osx]
+    # The web viewer cross-compiles ring's C sources to wasm32. The build
+    # scripts scope these tools to that target so native compilers are intact.
+    - clang
+    - llvm-tools
     # needed to get protoc for to lance
     - libprotobuf
     # gilrs (gamepad support, new in rerun 0.34.0) uses libudev-sys on linux,


### PR DESCRIPTION
Closes #75.

## What changed

- use unpinned `clang` and `llvm-tools` build dependencies on every platform;
- configure `CC`, `CXX`, and `AR` only for `wasm32-unknown-unknown`;
- clear conda's generic native C/C++ flags only while building the web viewer, restoring them automatically before the native CLI and Python extension builds;
- remove the global `AR`/`CC`/`CFLAGS` overrides, hard-coded Clang 16/19 resource paths, and temporary Windows diagnostics.

## Why

The original workaround in #70 covered two independent problems. The `psm`/`stacker` archiver path is no longer present in Rerun 0.36's `Cargo.lock`, and the macOS portability fix was subsequently merged upstream in rust-lang/stacker#128. `ring 0.17.14` remains and still needs a real WASM-capable compiler.

Rerun 0.36 locks `cc 1.4.0`. That crate already knows to use Clang and LLVM's archiver for WASM (rust-lang/cc-rs#381 and rust-lang/cc-rs#657), but conda compiler activation supplies generic native tools and flags. Target-qualified tool variables take precedence; flag variables are additive. This change therefore selects `clang`/`clang++`/`llvm-ar` specifically for WASM and isolates generic native flags only for the web-viewer command. Native GCC/MSVC/Clang activation is otherwise left intact.

`-fno-stack-protector` is retained, but is now target-only rather than mixed with resource-directory and host flags.

## Validation

- `conda-smithy recipe-lint recipe`
- `bash -n recipe/build.sh`
- `git diff --check`
- isolated `ring 0.17.14` WASM release build with Rerun's exact `cc 1.4.0`, Rust 1.95, and conda-forge Clang/LLVM tools; deliberately invalid generic `CC`, `CXX`, `AR`, `CFLAGS`, `CXXFLAGS`, and `TARGET_*FLAGS` were supplied to verify the target scoping and temporary flag isolation
- confirmed `clang` and `llvm-tools` are published for linux-64, linux-aarch64, osx-64, osx-arm64, and win-64

The full feedstock matrix is still the authoritative cross-platform validation.

## Review question

@ntjohnson1, do you recall whether `-fno-stack-protector` addressed an independent `wasm-bindgen` requirement, or only counteracted conda's generic host `CFLAGS`? I kept it conservatively and target-scoped here. If it may now be obsolete, I suggest testing its removal separately so this cleanup does not combine two behavioral changes.
